### PR TITLE
Add condition tags

### DIFF
--- a/lib/cfn-tags.js
+++ b/lib/cfn-tags.js
@@ -38,4 +38,7 @@ const tags = [];
 // !Ref だけ特別
 tags.push(newCfnTag(`!Ref`, `Ref`, 'scalar'));
 
+tags.push(newCfnTag(`!Condition`, `Condition`, 'scalar'));
+
+
 module.exports = tags;


### PR DESCRIPTION
`!Condition` tags are used within an `!And` (for example).

Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html